### PR TITLE
[BUGFIX] Add addtional check for [Empty] value

### DIFF
--- a/Classes/Domain/Finisher/EmailTemplateFinisher.php
+++ b/Classes/Domain/Finisher/EmailTemplateFinisher.php
@@ -10,7 +10,8 @@ class EmailTemplateFinisher extends EmailFinisher
 {
     protected function executeInternal(): void
     {
-        if (!empty($this->options['emailTemplate'])) {
+        // For v10 compatibility reasons we check for [Empty] value
+        if (!empty($this->options['emailTemplate']) && $this->options['emailTemplate'] !== '[Empty]') {
             $this->setOption('templateName', $this->options['emailTemplate']);
         }
         parent::executeInternal();

--- a/Configuration/Yaml/FormSetup.yaml
+++ b/Configuration/Yaml/FormSetup.yaml
@@ -36,7 +36,9 @@
           items:
             0:
               - "Default"
-              - ""
+              # The default value is required for v10, otherwise this will show up as "INVALID VALUE"
+              # can be set to "" (empty string) once we support v11 and up only.
+              - "[Empty]"
 TYPO3:
   CMS:
     Form:


### PR DESCRIPTION
In v10 the default flexform override settings have a hardcoded
value of "[Empty]" which triggered  the template selector and caused
the frontend to break.

This has been fixed by adding an additional check for [Empty] value
which will not triggere the template select logic anymore.