### PR TITLE
[TASK] Disable search engine indexing, remove fields in backend

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -34,9 +34,15 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
                 ],
             ],
             // Show only fields useful in email context
+            'palettes' => [
+                'visibilityEmailTemplate' => [
+                    'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.palettes.visibility',
+                    'showitem' => 'hidden;LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:pages.hidden_toggle_formlabel',
+                ]
+            ],
             'types' => [
                 $emailDoktype => [
-                    'showitem' => '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general, --palette--;;standard, --palette--;;title, --div--;LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.tabs.seo, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.appearance, --palette--;;layout, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.behaviour, --palette--;;miscellaneous, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.resources, --palette--;;media, --palette--;;config, --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language, --palette--;;language, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.access, --palette--;;visibility, --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
+                    'showitem' => '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general, --palette--;;standard, --palette--;;title, --div--;LLL:EXT:seo/Resources/Private/Language/locallang_tca.xlf:pages.tabs.seo, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.appearance, --palette--;;layout, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.resources, --palette--;;media, --palette--;;config, --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language, --palette--;;language, --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.tabs.access, --palette--;;visibilityEmailTemplate, --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:extended',
                 ],
             ],
         ]

--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -37,7 +37,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
             'palettes' => [
                 'visibilityEmailTemplate' => [
                     'label' => 'LLL:EXT:frontend/Resources/Private/Language/locallang_tca.xlf:pages.palettes.visibility',
-                    'showitem' => 'hidden;LLL:EXT:core/Resources/Private/Language/locallang_tca.xlf:pages.hidden_toggle_formlabel',
+                    'showitem' => 'hidden',
                 ]
             ],
             'types' => [

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -85,3 +85,18 @@ plugin.tx_form_custom_templates {
         templatePath = EXT:form_custom_templates/Resources/Private/Frontend/Partials/ResultTable
     }
 }
+
+plugin.tx_seo {
+    config {
+        xmlSitemap {
+            sitemaps {
+                pages {
+                    config {
+                        # Exclude the email template page type from showing up in the sitemap
+                        excludedDoktypes := addToList({$plugin.tx_form_custom_templates.doktype})
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Configuration/TypoScript/setup.typoscript
+++ b/Configuration/TypoScript/setup.typoscript
@@ -39,6 +39,9 @@ plugin.tx_form {
         typeNum = 0
         config {
             disableAllHeaderCode = 1
+            additionalHeaders {
+                125.header = X-Robots-Tag: noindex
+            }
         }
         10 = FLUIDTEMPLATE
         10 {


### PR DESCRIPTION
* HTML and Plaintext have `x-robots-tag: noindex` set now, so search engines should be adviced not to index these pages
* Remove fields not needed in email context

Todo:
- [x] Set “noindex=1” in database to avoid pages to show up in the sitemap.xml